### PR TITLE
ci: skip quarantine tests on PRs and pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,10 @@ jobs:
 
   test-quarantined:
     name: Test Quarantined
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     runs-on: macos-26
     timeout-minutes: 120
     continue-on-error: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ CI builds (`ci.yml`) are intentionally **unsigned** for speed and fork compatibi
 
 **CI workflow details**:
 - `test-required-stable` (required): main CI signal, runs coverage-enabled tests excluding quarantined classes
-- `test-quarantined` (informational): runs unstable/heavy classes and reports failures without blocking merges
+- `test-quarantined` (informational): runs unstable/heavy classes on releases (tag pushes), nightly schedule, and manual dispatch only — skipped on PRs and pushes to main
 - `lint` (informational): strict lint for changed `.swift` files; violations reported but do not block merge
 - `build-release` (required): validates Release configuration on PRs and main
 - Run full suite locally: `xcodebuild -project Muesli.xcodeproj -scheme Muesli test`


### PR DESCRIPTION
## Summary
- Quarantine tests (hardware-dependent, flaky suites) now only run on tag pushes (releases), nightly schedule, and manual workflow dispatch
- Skipped on PRs and pushes to main to avoid burning CI minutes on informational-only tests during normal PR workflows
- Updated AGENTS.md documentation to reflect the new behavior

## Test plan
- [ ] Verify quarantine job shows as "skipped" on this PR's CI run
- [ ] Confirm stable tests, lint, and release build still run normally

Made with [Cursor](https://cursor.com)