### PR TITLE
chore: Bump version to 0.6.2

### DIFF
--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -7,7 +7,7 @@
 //
 
 // Marketing version (user-facing version number, follows semantic versioning)
-MARKETING_VERSION = 0.6.2-rc.5
+MARKETING_VERSION = 0.6.2
 
 // Build number (incremented for each build/release)
 CURRENT_PROJECT_VERSION = 1


### PR DESCRIPTION
Removes -rc.5 suffix for stable release.